### PR TITLE
Potentially work around https://github.com/JuliaLang/julia/issues/9185

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -41,13 +41,14 @@ for name in all_names:
     if name[-3:] == 'x86':
         deb_arch = 'i386'
         tar_arch = 'i386'
-        march = 'pentium4'
+        march = 'i686'
         up_arch = 'x86'
         bits = '32'
+        flags += 'JULIA_CPU_TARGET=pentium4'
 
     # On windows, add XC_HOST dependent on the architecture
     if name[:3] == 'win':
-        if march == 'pentium4':
+        if march == 'i686':
             flags += 'XC_HOST=i686-w64-mingw32 '
         else:
             flags += 'XC_HOST=x86_64-w64-mingw32 '


### PR DESCRIPTION
This might be a x87-vs-SSE problem, since setting march to i686 for building the deps
but JULIA_CPU_TARGET to pentium4 for JIT code appears to work properly.
Need to verify that this doesn't bring back any of the i686 issues on 32 bit linux though.
