### PR TITLE
process stdlib folders

### DIFF
--- a/master/coverage.py
+++ b/master/coverage.py
@@ -14,7 +14,7 @@ cd(joinpath(CoverageBase.julia_top()))
 results = Coverage.process_folder("base")
 if isdefined(CoverageBase.BaseTestRunner, STDLIBS)
     for stdlib in CoverageBase.BaseTestRunner.STDLIBS
-        results = Coverage.process_folder("stdlib/$stdlib/src")
+        append!(results, Coverage.process_folder("stdlib/$stdlib/src"))
     end
 end
 

--- a/master/coverage.py
+++ b/master/coverage.py
@@ -12,6 +12,11 @@ using Coverage, CoverageBase, Compat
 
 cd(joinpath(CoverageBase.julia_top()))
 results = Coverage.process_folder("base")
+if isdefined(CoverageBase.BaseTestRunner, STDLIBS)
+    for stdlib in CoverageBase.BaseTestRunner.STDLIBS
+        results = Coverage.process_folder("stdlib/$stdlib/src")
+    end
+end
 
 # Create git_info for Coveralls
 git_info = Dict(


### PR DESCRIPTION
Try to add `stdlib/*/src` to the Coverage results. Not sure how to test this, so I could only made sure it parses. (@staticfloat)