### PR TITLE
Use ccache everywhere

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -93,7 +93,6 @@ for name in all_names:
         bits = 'aarch64'
         march = 'armv8-a'
         flags += 'JULIA_CPU_TARGET=generic '
-        flags += 'LLVM_VER=3.9.1 '
 
     # On windows, disable running doc/genstdlib.jl due to julia issue #11727
     # and add XC_HOST dependent on the architecture

--- a/master/inventory.py
+++ b/master/inventory.py
@@ -43,8 +43,8 @@ for name in all_names:
         os_name = "linux"
         os_pkg_ext = "tar.gz"
 
-        # Use ccache on Linux builds
-        flags += 'USECCACHE=1 '
+    # Use ccache everywhere
+    flags += 'USECCACHE=1 '
 
 
 

--- a/master/package.py
+++ b/master/package.py
@@ -19,42 +19,13 @@ julia_package_factory.addSteps([
     steps.Git(
         name="Julia checkout",
         repourl=util.Property('repository', default='git://github.com/JuliaLang/julia.git'),
-        mode='incremental',
-        method='clean',
+        mode='full',
+        method='fresh',
         submodules=True,
         clobberOnFailure=True,
         progress=True
     ),
 
-    # If we're on linux, we're super fast and we use ccache.  So auto-nuke.
-    steps.ShellCommand(
-        name="git clean -fdx, if we use ccache",
-        command=["git", "clean", "-fdx"],
-        doStepIf=is_linux,
-        flunkOnFailure=False,
-    ),
-
-    # make clean first
-    steps.ShellCommand(
-        name="make cleanall",
-        command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s %(prop:extra_make_flags)s cleanall")],
-        env=julia_package_env,
-    ),
-
-    # Cleanup old julia build directories, .dmg files, etc...
-    steps.ShellCommand(
-        name="Clean out temporary windows cruft",
-        command=["/bin/bash", "-c", "rm -rf julia-*"],
-        flunkOnFailure=False,
-    ),
-
-    # Clear out old .cov and .mem files.  Note that this should be removed once we always start from scratch. 
-    steps.ShellCommand(
-        name="Clear out usr",
-        command=["/bin/bash", "-c", "find . \( -name *.jl.*.cov -o -name *.jl.mem \) -print -delete"],
-        env=julia_package_env,
-    ),
- 
     # Get win-extras files ready on windows
     steps.ShellCommand(
         name="make win-extras",


### PR DESCRIPTION
I installed ccache on Windows and the mac bot. 
While deleting files on Windows will still be slow, this allows us 
more consistent builds (and builds for release-0.6)