### PR TITLE
Set -jN per machine and add stats for ccache

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -110,8 +110,10 @@ for name in all_names:
 
         # Our OSX builder only devotes 2 cores to each VM
         flags += 'JULIA_CPU_CORES=2 '
+        nthreads = 3
     else:
         flags += 'JULIA_CPU_CORES=6 '
+        nthreads = 6
 
     # tests are hitting memory issues, so restart workers when memory consumption gets too high
     flags += 'JULIA_TEST_MAXRSS_MB=1000 '
@@ -127,6 +129,7 @@ for name in all_names:
                 'tar_arch':tar_arch,
                 'release':name,
                 'flags':flags,
+                'nthreads':nthreads,
                 'up_arch':up_arch,
                 'bits':bits,
                 'llvm_cmake':llvm_cmake,

--- a/master/package.py
+++ b/master/package.py
@@ -15,6 +15,17 @@ julia_package_factory.addSteps([
         flunkOnFailure=False
     ),
 
+    # Recursive `git clean` on windows is very slow. It is faster to
+    # wipe the dir and reset it. Important is that we don't delete our
+    # `.git` folder
+    steps.ShellCommand(
+        name="[Win] wipe state",
+        command=["/bin/bash", "-c", "cmd /c del /s /q *"],
+        flunkOnFailure = False,
+        doStepIf=is_windows,
+        env=julia_package_env,
+    ),
+
     # Clone julia
     steps.Git(
         name="Julia checkout",

--- a/master/package.py
+++ b/master/package.py
@@ -51,6 +51,15 @@ julia_package_factory.addSteps([
         env=julia_package_env,
     ),
 
+    # Get info about ccache
+    steps.ShellCommand(
+        name="ccache stats",
+        command=["/bin/bash", "-c", "ccache -s -p"],
+        haltOnFailure = False,
+        timeout=3600,
+        env=julia_package_env,
+    ),
+
     # Set a bunch of properties that are useful down the line
     steps.SetPropertyFromCommand(
         name="Get commitmessage",

--- a/master/package.py
+++ b/master/package.py
@@ -38,14 +38,14 @@ julia_package_factory.addSteps([
     # Make, forcing some degree of parallelism to cut down compile times
     steps.ShellCommand(
         name="make release",
-        command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s %(prop:extra_make_flags)s release")],
+        command=["/bin/bash", "-c", util.Interpolate("make -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s release")],
         haltOnFailure = True,
         timeout=3600,
         env=julia_package_env,
     ),
     steps.ShellCommand(
         name="make debug",
-        command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s %(prop:extra_make_flags)s debug")],
+        command=["/bin/bash", "-c", util.Interpolate("make -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s debug")],
         haltOnFailure = True,
         timeout=3600,
         env=julia_package_env,


### PR DESCRIPTION
Builds with ccache are better than from scratch, but they still take a
lot of time. Add stats so that we can monitor whether our cache is big enough
and increase the number of paralle make jobs.