### PR TITLE
Run build steps with /bin/sh instead of /bin/bash

### DIFF
--- a/master/auto_reload.py
+++ b/master/auto_reload.py
@@ -8,7 +8,7 @@ reload_factory.addSteps([
     # Fetch first (allowing failure if no existing clone is present)
     steps.MasterShellCommand(
         name="Reload buildbot configuration",
-        command=["/bin/bash", "-c", "cd /buildbot; git pull && buildbot reconfig master && git log -1"],
+        command=["/bin/sh", "-c", "cd /buildbot; git pull && buildbot reconfig master && git log -1"],
         flunkOnFailure=True
     )
 ])

--- a/master/builder_utils.py
+++ b/master/builder_utils.py
@@ -128,24 +128,24 @@ def munge_artifact_filename(props_obj):
 def render_upload_command(props_obj):
     upload_path = gen_upload_path(props_obj, namespace="pretesting")
     upload_filename = props_obj.getProperty("upload_filename")
-    return ["/bin/bash", "-c", "aws s3 cp --acl public-read /tmp/julia_package/%s s3://%s"%(upload_filename, upload_path)]
+    return ["/bin/sh", "-c", "aws s3 cp --acl public-read /tmp/julia_package/%s s3://%s"%(upload_filename, upload_path)]
 
 @util.renderer
 def render_promotion_command(props_obj):
     src_path = gen_upload_path(props_obj, namespace="pretesting")
     dst_path = gen_upload_path(props_obj)
-    return ["/bin/bash", "-c", "aws s3 cp --acl public-read s3://%s s3://%s"%(src_path, dst_path)]
+    return ["/bin/sh", "-c", "aws s3 cp --acl public-read s3://%s s3://%s"%(src_path, dst_path)]
 
 @util.renderer
 def render_latest_promotion_command(props_obj):
     src_path = gen_upload_path(props_obj, namespace="pretesting")
     dst_path = gen_latest_upload_path(props_obj)
-    return ["/bin/bash", "-c", "aws s3 cp --acl public-read s3://%s s3://%s"%(src_path, dst_path)]
+    return ["/bin/sh", "-c", "aws s3 cp --acl public-read s3://%s s3://%s"%(src_path, dst_path)]
 
 @util.renderer
 def render_cleanup_pretesting_command(props_obj):
     del_path = gen_upload_path(props_obj, namespace="pretesting")
-    return ["/bin/bash", "-c", "aws s3 rm s3://%s"%(del_path)]
+    return ["/bin/sh", "-c", "aws s3 rm s3://%s"%(del_path)]
 
 @util.renderer
 def render_download_url(props_obj):
@@ -162,13 +162,13 @@ def render_make_app(props_obj):
     new_way = "make {flags} app".format(**props)
     old_way = "make {flags} -C contrib/mac/app && mv contrib/mac/app/*.dmg {local_filename}".format(**props)
 
-    # We emit a bash command that attempts to run `make app` (which is the nice
+    # We emit a shell command that attempts to run `make app` (which is the nice
     # `sf/consistent_distnames` shortcut), and if that fails, it runs the steps
     # manually, which boil down to `make -C contrib/mac/app` and moving the
     # result to the top-level, where we can find it.  We can remove this once
     # 0.6 is no longer being built.
     return [
-        "/bin/bash",
+        "/bin/sh",
         "-c",
         "~/unlock_keychain.sh && (%s || (%s))"%(new_way, old_way)
     ]
@@ -200,7 +200,7 @@ def build_download_julia_cmd(props_obj):
     else:
         # Oh linux.  Your simplicity always gets me
         cmd = "curl -L '%s' | tar --strip-components=1 -zx"%(download_url)
-    return ["/bin/bash", "-c", cmd]
+    return ["/bin/sh", "-c", cmd]
 
 
 @util.renderer

--- a/master/coverage.py
+++ b/master/coverage.py
@@ -60,19 +60,19 @@ julia_coverage_factory.addSteps([
     # Clean the place out from previous runs
     steps.ShellCommand(
         name="clean it out",
-        command=["/bin/bash", "-c", "rm -rf *"]
+        command=["/bin/sh", "-c", "rm -rf *"]
     ),
 
     # Download the appropriate tarball and extract it
     steps.ShellCommand(
         name="download/extract tarball",
-        command=["/bin/bash", "-c", util.Interpolate("curl -L %(prop:url)s | tar zx")],
+        command=["/bin/sh", "-c", util.Interpolate("curl -L %(prop:url)s | tar zx")],
     ),
 
     # Find Julia directory (so we don't have to know the shortcommit)
     steps.SetPropertyFromCommand(
         name="Find Julia executable",
-        command=["/bin/bash", "-c", "echo julia-*"],
+        command=["/bin/sh", "-c", "echo julia-*"],
         property="juliadir"
     ),
 

--- a/master/llvm_extras.py
+++ b/master/llvm_extras.py
@@ -30,14 +30,14 @@ llvm_extras_factory.addSteps([
     # make clean first
     steps.ShellCommand(
         name="make distcleanall",
-        command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s BUILD_LLVM_CLANG=1 %(prop:extra_make_flags)s -C deps distcleanall")],
+        command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s BUILD_LLVM_CLANG=1 %(prop:extra_make_flags)s -C deps distcleanall")],
         env=llvm_extras_env,
     ),
 
     # Our llvm build process fails to properly create `$(build_libdir)` before installing llvm, so let's do it first
     steps.ShellCommand(
         name="make usr/lib",
-        command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s BUILD_LLVM_CLANG=1 %(prop:extra_make_flags)s usr/lib")],
+        command=["/bin/sh", "-c", util.Interpolate("make -j3 %(prop:flags)s BUILD_LLVM_CLANG=1 %(prop:extra_make_flags)s usr/lib")],
         haltOnFailure = True,
         timeout=3600,
         env=llvm_extras_env,
@@ -46,7 +46,7 @@ llvm_extras_factory.addSteps([
     # Make, forcing some degree of parallelism to cut down compile times
     steps.ShellCommand(
         name="make",
-        command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s BUILD_LLVM_CLANG=1 %(prop:extra_make_flags)s -C deps install-llvm")],
+        command=["/bin/sh", "-c", util.Interpolate("make -j3 %(prop:flags)s BUILD_LLVM_CLANG=1 %(prop:extra_make_flags)s -C deps install-llvm")],
         haltOnFailure = True,
         timeout=3600,
         env=llvm_extras_env,
@@ -83,7 +83,7 @@ llvm_extras_factory.addSteps([
     steps.MasterShellCommand(
         name="Upload to AWS",
         command=[
-            "/bin/bash",
+            "/bin/sh",
             "-c",
             util.Interpolate("aws s3 cp --acl public-read /tmp/llvm_extras/llvm_extras-%(prop:shortcommit)s-%(prop:os_name)s%(prop:bits)s.tar.gz s3://julialangmirror/llvm_extras-%(prop:shortcommit)s-%(prop:os_name)s%(prop:bits)s.tar.gz")
         ],

--- a/master/llvmjl.py
+++ b/master/llvmjl.py
@@ -29,7 +29,7 @@ llvmjl_factory.addSteps([
     # Cleanup
     steps.ShellCommand(
         name="Cleanup",
-        command=["bash", "-c", "rm -rf *"],
+        command=["/bin/sh", "-c", "rm -rf *"],
     ),
 
     # Download Julia
@@ -40,7 +40,7 @@ llvmjl_factory.addSteps([
     # Download llvm-extras
     steps.ShellCommand(
         name="Download llvm-extras",
-        command=["bash", "-c", util.Interpolate("cd julia-*; curl -L 'https://s3.amazonaws.com/julialangmirror/llvm_extras-%(prop:shortcommit)s-%(prop:os_name)s%(prop:bits)s.tar.gz' | tar -zxv --strip-components=1")],
+        command=["/bin/sh", "-c", util.Interpolate("cd julia-*; curl -L 'https://s3.amazonaws.com/julialangmirror/llvm_extras-%(prop:shortcommit)s-%(prop:os_name)s%(prop:bits)s.tar.gz' | tar -zxv --strip-components=1")],
     ),
 
     # Invoke Julia to build LLVM
@@ -72,7 +72,7 @@ llvmjl_factory.addSteps([
     steps.MasterShellCommand(
         name="Upload to AWS",
         command=[
-            "/bin/bash",
+            "/bin/sh",
             "-c",
             util.Interpolate("aws s3 cp --acl public-read /tmp/llvm_jl/llvmjl-%(prop:revision)s-%(prop:shortcommit)s-%(prop:os_name)s%(prop:bits)s.tar.gz s3://julialangmirror/llvmjl-%(prop:revision)s-%(prop:shortcommit)s-%(prop:os_name)s%(prop:bits)s.tar.gz")
         ],

--- a/master/nightly_gc_debug.py
+++ b/master/nightly_gc_debug.py
@@ -32,20 +32,20 @@ julia_gc_debug_factory.addSteps([
     # make clean first, and nuke llvm
     steps.ShellCommand(
     	name="make cleanall",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s cleanall")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s cleanall")]
     ),
 
     # Make!
     steps.ShellCommand(
     	name="make",
-    	command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s")],
+    	command=["/bin/sh", "-c", util.Interpolate("make -j3 %(prop:flags)s")],
     	haltOnFailure = True
     ),
 
     # Test!
     steps.ShellCommand(
     	name="make testall",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s testall")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s testall")]
     )
 ])
 

--- a/master/nightly_llvmsvn.py
+++ b/master/nightly_llvmsvn.py
@@ -32,17 +32,17 @@ julia_llvmsvn_factory.addSteps([
     # make clean first, and nuke llvm
     steps.ShellCommand(
     	name="make cleanall",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s cleanall")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s cleanall")]
     ),
     steps.ShellCommand(
     	name="make distclean-llvm",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s -C deps distclean-llvm")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s -C deps distclean-llvm")]
     ),
 
     # Make!
     steps.ShellCommand(
     	name="make",
-    	command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s")],
+    	command=["/bin/sh", "-c", util.Interpolate("make -j3 %(prop:flags)s")],
     	haltOnFailure = True
     ),
 
@@ -55,7 +55,7 @@ julia_llvmsvn_factory.addSteps([
     # Test!
     steps.ShellCommand(
     	name="make testall",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s testall")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s testall")]
     )
 ])
 

--- a/master/nightly_threading.py
+++ b/master/nightly_threading.py
@@ -51,20 +51,20 @@ julia_threading_factory.addSteps([
     # make clean first
     steps.ShellCommand(
     	name="make cleanall",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s cleanall")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s cleanall")]
     ),
 
     # Make!
     steps.ShellCommand(
         name="make binary-dist",
-        command=["/bin/bash", "-c", util.Interpolate("make -j3 %(prop:flags)s binary-dist")],
+        command=["/bin/sh", "-c", util.Interpolate("make -j3 %(prop:flags)s binary-dist")],
         haltOnFailure = True
     ),
 
     # Test!
     steps.ShellCommand(
     	name="make testall",
-    	command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s testall")]
+    	command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s testall")]
     ),
 
     steps.SetPropertyFromCommand(

--- a/master/nuclear_arsenal.py
+++ b/master/nuclear_arsenal.py
@@ -7,7 +7,7 @@ nuclear_arsenal = {
     "nuke": {
         "label": "Nuke all build/package directories",
         "command": [
-            "/bin/bash",
+            "/bin/sh",
             "-c",
             "if [ `uname` = Darwin ]; \
                 then sudo rm -rf ../../{package_,build_,coverage_,juno_,nightly_,perf_}*; \

--- a/master/package.py
+++ b/master/package.py
@@ -20,7 +20,7 @@ julia_package_factory.addSteps([
     # `.git` folder
     steps.ShellCommand(
         name="[Win] wipe state",
-        command=["/bin/bash", "-c", "cmd /c del /s /q *"],
+        command=["/bin/sh", "-c", "cmd /c del /s /q *"],
         flunkOnFailure = False,
         doStepIf=is_windows,
         env=julia_package_env,
@@ -40,7 +40,7 @@ julia_package_factory.addSteps([
     # Get win-extras files ready on windows
     steps.ShellCommand(
         name="make win-extras",
-        command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s %(prop:extra_make_flags)s win-extras")],
+        command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s %(prop:extra_make_flags)s win-extras")],
         haltOnFailure = True,
         doStepIf=is_windows,
         env=julia_package_env,
@@ -49,14 +49,14 @@ julia_package_factory.addSteps([
     # Make, forcing some degree of parallelism to cut down compile times
     steps.ShellCommand(
         name="make release",
-        command=["/bin/bash", "-c", util.Interpolate("make -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s release")],
+        command=["/bin/sh", "-c", util.Interpolate("make -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s release")],
         haltOnFailure = True,
         timeout=3600,
         env=julia_package_env,
     ),
     steps.ShellCommand(
         name="make debug",
-        command=["/bin/bash", "-c", util.Interpolate("make -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s debug")],
+        command=["/bin/sh", "-c", util.Interpolate("make -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s debug")],
         haltOnFailure = True,
         timeout=3600,
         env=julia_package_env,
@@ -65,7 +65,7 @@ julia_package_factory.addSteps([
     # Get info about ccache
     steps.ShellCommand(
         name="ccache stats",
-        command=["/bin/bash", "-c", "ccache -s"],
+        command=["/bin/sh", "-c", "ccache -s"],
         flunkOnFailure=False,
         env=julia_package_env,
     ),
@@ -97,7 +97,7 @@ julia_package_factory.addSteps([
     # Make binary-dist to package it up
     steps.ShellCommand(
         name="make binary-dist",
-        command=["/bin/bash", "-c", util.Interpolate("make %(prop:flags)s %(prop:extra_make_flags)s binary-dist")],
+        command=["/bin/sh", "-c", util.Interpolate("make %(prop:flags)s %(prop:extra_make_flags)s binary-dist")],
         haltOnFailure = True,
         timeout=3600,
         env=julia_package_env,

--- a/master/separated_testing.py
+++ b/master/separated_testing.py
@@ -19,7 +19,7 @@ julia_testing_factory.addSteps([
     # Clean the place out from previous runs
     steps.ShellCommand(
         name="clean it out",
-        command=["/bin/bash", "-c", "rm -rf *"],
+        command=["/bin/sh", "-c", "rm -rf *"],
         flunkOnFailure=False,
     ),
 

--- a/master/sign_juno.py
+++ b/master/sign_juno.py
@@ -9,13 +9,13 @@ sign_juno_factory.addSteps([
     steps.ShellCommand(command=["/usr/bin/curl", "-L", "https://raw.githubusercontent.com/JuliaCI/julia-buildbot/master/commands/sign_juno.sh", "-o", "sign_juno.sh"]),
 
     # Invoke it
-    steps.ShellCommand(command=["/bin/bash", "sign_juno.sh", util.Property('osx64_url'), util.Property('win32_url'), util.Property('win64_url')], haltOnFailure=True),
+    steps.ShellCommand(command=["/bin/sh", "sign_juno.sh", util.Property('osx64_url'), util.Property('win32_url'), util.Property('win64_url')], haltOnFailure=True),
 
     # Grab the output and transfer it back!
-    steps.SetPropertyFromCommand(name="Get filename", command=["/bin/bash", "-c", "ls *-signed*"], property="filename"),
+    steps.SetPropertyFromCommand(name="Get filename", command=["/bin/sh", "-c", "ls *-signed*"], property="filename"),
     steps.MasterShellCommand(name="mkdir juno_cache", command=["mkdir", "-p", "/tmp/juno_cache"]),
     steps.FileUpload(workersrc=util.Interpolate("%(prop:filename)s"), masterdest=util.Interpolate("/tmp/juno_cache/%(prop:filename)s")),
-    steps.MasterShellCommand(name="Upload to AWS", command=["/bin/bash", "-c", util.Interpolate("aws s3 cp --acl public-read /tmp/juno_cache/%(prop:filename)s s3://junolab/latest/signed/%(prop:filename)s")], haltOnFailure=True),
+    steps.MasterShellCommand(name="Upload to AWS", command=["/bin/sh", "-c", util.Interpolate("aws s3 cp --acl public-read /tmp/juno_cache/%(prop:filename)s s3://junolab/latest/signed/%(prop:filename)s")], haltOnFailure=True),
 
     # Cleanup!
     steps.MasterShellCommand(name="Cleanup", command=["rm", "-f", util.Interpolate("/tmp/juno_cache/%(prop:filename)s")])


### PR DESCRIPTION
Using `/bin/bash` is problematic for systems such as FreeBSD, which do not have Bash preinstalled, and on which installing Bash does not create `/bin/bash`. There does not appear to be anything Bash-specific that we're using, so using regular POSIX `sh` should be just fine.