### PR TITLE
Remove duplicate `armv7-a` entry in `JULIA_CPU_TARGET`

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -79,7 +79,7 @@ for name in all_names:
         bits = 'armv7l'
 
         # Sysimg multi-versioning!
-        flags += 'JULIA_CPU_TARGET="armv7-a;armv7-a,neon;armv7-a;armv7-a,neon,vfp4" '
+        flags += 'JULIA_CPU_TARGET="armv7-a;armv7-a,neon;armv7-a,neon,vfp4" '
         # Force LLVM cmake build to use the armv7 triple instead of armv8 from uname
         # This might not be an actual issue since we are not building clang, but BSTS
         llvm_cmake = '-DLLVM_HOST_TRIPLE=armv7l-unknown-linux-gnueabihf -DLLVM_DEFAULT_TARGET_TRIPLE=armv7l-unknown-linux-gnueabihf'


### PR DESCRIPTION
@vchuravy @yuyichao 

Just to double-check, this was a typo right?  There's no reason to have duplicate entries in this list?