### PR TITLE
Add `analyzegc` scheduler that gets run alongside normal packaging

### DIFF
--- a/master/analyzegc.py
+++ b/master/analyzegc.py
@@ -1,0 +1,73 @@
+# Steps to build a `make binary-dist` tarball that should work on just about every linux ever
+julia_analyzegc_factory = util.BuildFactory()
+julia_analyzegc_factory.useProgress = True
+julia_analyzegc_factory.addSteps([
+    # Clone julia
+    steps.Git(
+        name="Julia checkout",
+        repourl=util.Property('repository', default='git://github.com/JuliaLang/julia.git'),
+        mode='full',
+        method='fresh',
+        submodules=True,
+        clobberOnFailure=True,
+        progress=True,
+        retryFetch=True,
+        getDescription={'--tags': True},
+    ),
+
+    # Install necessary dependencies
+    steps.ShellCommand(
+        name="install dependencies",
+        command=["/bin/sh", "-c", util.Interpolate("%(prop:make_cmd)s -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s -C deps install-llvm install-libuv install-utf8proc install-unwind")],
+        haltOnFailure = True,
+    ),
+    
+    # Install necessary dependencies
+    steps.ShellCommand(
+        name="install dependencies",
+        command=["/bin/sh", "-c", util.Interpolate("%(prop:make_cmd)s -j%(prop:nthreads)s %(prop:flags)s %(prop:extra_make_flags)s -C src analyzegc")],
+        haltOnFailure = True,
+    ),
+])
+
+# This is the CI scheduler, where we build an assert build and test it
+c['schedulers'].append(schedulers.AnyBranchScheduler(
+    name="Julia GC Analysis",
+    change_filter=util.ChangeFilter(filter_fn=julia_ci_filter),
+    builderNames=["analyzegc_linux64"],
+    treeStableTimer=1,
+))
+
+# Add workers for these jobs
+c['builders'].append(util.BuilderConfig(
+    name="analyzegc_linux64",
+    workernames=builder_mapping["linux64"],
+    collapseRequests=False,
+    tags=["Packaging"],
+    factory=julia_analyzegc_factory,
+))
+
+# Add a scheduler for building release candidates/triggering builds manually
+c['schedulers'].append(schedulers.ForceScheduler(
+    name="analyzegc",
+    label="Force GC analysis",
+    builderNames=["analyzegc_linux64"],
+    reason=util.FixedParameter(name="reason", default=""),
+    codebases=[
+        util.CodebaseParameter(
+            "",
+            name="",
+            branch=util.FixedParameter(name="branch", default=""),
+            repository=util.FixedParameter(name="repository", default=""),
+            project=util.FixedParameter(name="project", default="Packaging"),
+        )
+    ],
+    properties=[
+        util.StringParameter(
+            name="extra_make_flags",
+            label="Extra Make Flags",
+            size=30,
+            default="",
+        ),
+    ],
+))

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -105,11 +105,10 @@ exec(open("inventory.py").read())
 # Load in useful utilities for dealing with builders
 exec(open("builder_utils.py").read())
 
-# Load in packaging for various platforms
+# Load in packaging, separated testing and GC analysis (all the stuff we run per-commit)
 exec(open("package.py").read())
-
-# Load in separated testing
 exec(open("separated_testing.py").read())
+exec(open("analyzegc.py").read())
 
 # Cleaning
 exec(open("cache_control.py").read())
@@ -117,7 +116,7 @@ exec(open("cache_control.py").read())
 # Load in code-executor
 exec(open("run_code.py").read())
 
-# Load in nightly tasks such as building Homebrew, building against LLVM SVN, etc...
+# Load in nightly tasks such as building with threading, GC debug runs, etc...
 exec(open("nightly_threading.py").read())
 exec(open("nightly_gc_debug.py").read())
 
@@ -136,7 +135,8 @@ package_report = reporters.GitHubStatusPush(
     context=util.Interpolate("buildbot/%(prop:buildername)s"),
     startDescription='Run started',
     builders=[("package_" + k) for k in status_builders] +
-             [("tester_"   + k) for k in status_builders],
+             [("tester_"   + k) for k in status_builders] +
+             ["analyzegc_linux64"],
     endDescription='Run complete',
 )
 c['services'].append(package_report)


### PR DESCRIPTION
This runs the `clang` static analysis target to analyze Julia's C source.  Closes #118.  Won't run successfully until https://github.com/JuliaLang/julia/pull/32171 is merged.