### PR TITLE
send SIGTERM before SIGKILL

### DIFF
--- a/master/coverage.py
+++ b/master/coverage.py
@@ -141,7 +141,12 @@ julia_coverage_factory.addSteps([
         command=[util.Interpolate("%(prop:juliadir)s/bin/julia"),
                  "--sysimage-native-code=no", util.Interpolate("--code-coverage=%(prop:juliadir)s/LCOV/cov-%%p.info"),
                  "-e", run_coverage_cmd],
-        timeout=3600,
+        # Fail out if 60 minutes have gone by with nothing printed to stdout
+        timeout=60*60,
+        # Kill everything if the overall job has taken more than 10 hours
+        maxTime=60*60*10,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
     #submit the results!
     steps.ShellCommand(

--- a/master/doctest.py
+++ b/master/doctest.py
@@ -30,6 +30,8 @@ julia_doctest_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 2 hours
         maxTime=60*60*2,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
 
     steps.ShellCommand(
@@ -40,6 +42,8 @@ julia_doctest_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 2 hours
         maxTime=60*60*2,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
 
     steps.ShellCommand(

--- a/master/llvmpasses.py
+++ b/master/llvmpasses.py
@@ -30,6 +30,8 @@ julia_llvmpasses_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 2 hours
         maxTime=60*60*2,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
 
     steps.ShellCommand(
@@ -40,6 +42,8 @@ julia_llvmpasses_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 2 hours
         maxTime=60*60*2,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
 ])
 

--- a/master/package.py
+++ b/master/package.py
@@ -85,6 +85,8 @@ julia_package_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 10 hours
         maxTime=60*60*10,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
         env=julia_package_env,
     ),
 
@@ -145,6 +147,8 @@ julia_package_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 10 hours
         maxTime=60*60*10,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
         env=julia_package_env,
     ),
 

--- a/master/separated_testing.py
+++ b/master/separated_testing.py
@@ -46,6 +46,8 @@ julia_testing_factory.addSteps([
         timeout=45*60,
         # Kill everything if the overall job has taken more than 10 hours
         maxTime=60*60*10,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
 
     # Promote from pretesting to a nightly if it worked!

--- a/master/whitespace.py
+++ b/master/whitespace.py
@@ -30,6 +30,8 @@ julia_whitespace_factory.addSteps([
         timeout=60*60,
         # Kill everything if the overall job has taken more than 2 hours
         maxTime=60*60*2,
+        # Give the process 10 seconds to print out the current backtraces when being killed
+        sigtermTime=10,
     ),
 ])
 


### PR DESCRIPTION
Found this mentioned at http://docs.buildbot.net/latest/manual/configuration/buildsteps.html#using-shellcommands @staticfloat 

