### PR TITLE
Drop coverage results from Pkg and Statistics

### DIFF
--- a/master/coverage.py
+++ b/master/coverage.py
@@ -56,6 +56,14 @@ allfiles = map(fn -> Coverage.FileCoverage(fn, read(CoverageBase.fixabspath(fn),
     [allfiles_base; allfiles_stdlib])
 results = Coverage.merge_coverage_counts(results, allfiles)
 length(results) == length(allfiles) || @warn "Got coverage for an unexpected file:" symdiff=symdiff(map(x -> x.filename, allfiles), map(x -> x.filename, results))
+  # drop vendored files
+  # todo: find a more general way to do this, as this may become hard to maintain
+let prefixes = (joinpath("stdlib", "Pkg", ""),
+                joinpath("stdlib", "Statistics", ""))
+    filter!(results) do c
+        all(p -> !startswith(c.filename, p), prefixes)
+    end
+end
   # attempt to improve accuracy of the results
 foreach(Coverage.amend_coverage_from_src!, results)
 # Create git_info for codecov


### PR DESCRIPTION
Currently, our coverage results are being impacted by including Pkg, even though we don't run the tests for it (we assume it has it's own test suite and coverage and releases—like any of our other vendored dependencies). There doesn't seem to be a good way to identify these right now, since we don't have vendored information in the build results. Maybe the Pkg folks have a plan for adding it. For now, this information doesn't change too often, so we should be alright with hard-coding it.

@staticfloat 