### PR TITLE
Add `INNO_ARGS` to automatically sign executables

### DIFF
--- a/master/package.py
+++ b/master/package.py
@@ -196,16 +196,6 @@ julia_package_factory.addSteps([
         env=julia_package_env,
     ),
 
-    # Sign windows installer .exe
-    steps.ShellCommand(
-        name="sign .exe (installer)",
-        command=["sh", "-c", util.Interpolate("~/sign.sh \"%(prop:local_filename)s\"")],
-        doStepIf=is_windows,
-        hideStepIf=lambda results, s: results==SKIPPED,
-        haltOnFailure=False,
-        flunkOnFailure=False,
-    ),
-
     # Transfer the result to the buildmaster for uploading to AWS
     steps.MasterShellCommand(
         name="mkdir julia_package",

--- a/master/package.py
+++ b/master/package.py
@@ -3,6 +3,7 @@ julia_package_env = {
     'CPPFLAGS': None,
     'LLVM_CMAKE': util.Property('llvm_cmake', default=None),
     'MACOS_CODESIGN_IDENTITY': MACOS_CODESIGN_IDENTITY,
+    'INNO_ARGS': '/Dsign=true "/Smysigntool=\$$q`cygpath -w /bin/sh`\$$q -c ~/sign.sh \$$f"',
 }
 
 # Steps to build a `make binary-dist` tarball that should work on every platform


### PR DESCRIPTION
@musm does this look reasonable to you?

We also have two manual signing steps: [we sign `usr/bin/julia.exe`](https://github.com/JuliaCI/julia-buildbot/blob/master/master/package.py#L134-L140) and [the eventual `julia-x.y.z.exe` installer](https://github.com/JuliaCI/julia-buildbot/blob/master/master/package.py#L198-L206).  Do we still need to do either of those?