### PR TITLE
Cleanup master after srcdist targets

### DIFF
--- a/master/doctest.py
+++ b/master/doctest.py
@@ -150,6 +150,12 @@ julia_doctest_factory.addSteps([
         doStepIf=is_protected_pr,
         hideStepIf=lambda results, s: results==SKIPPED,
     ),
+    steps.MasterShellCommand(
+        name="Cleanup Master",
+        command=["sh", "-c", util.Interpolate("rm -vf /tmp/julia_package/julia-%(prop:JULIA_VERSION)s_%(prop:JULIA_COMMIT)s* ;")],
+        flunkOnFailure=False
+        haltOnFailure=False,
+    ),
 ])
 
 c['schedulers'].append(schedulers.AnyBranchScheduler(


### PR DESCRIPTION
We were leaking big srcdist tarballs into `/tmp`.  Note to self; a better architecture for these things is to do all work in a folder namespaced by job ID, then just `rm -rf /tmp/${job_id}` at the end.  We should make sure buildkite makes it easy to do that.