### PR TITLE
Move coverage to a nightly schedule

### DIFF
--- a/master/coverage.py
+++ b/master/coverage.py
@@ -165,16 +165,25 @@ julia_coverage_factory.addSteps([
     ),
 ])
 
-
-# Add a dependent scheduler for running coverage after we build tarballs
-julia_coverage_builders = ["coverage_linux64"]
-julia_coverage_scheduler = schedulers.Triggerable(name="Julia Coverage Testing", builderNames=julia_coverage_builders)
-c['schedulers'].append(julia_coverage_scheduler)
+# Add a nightly scheduled build for Coverage
+coverage_nightly_scheduler = schedulers.Nightly(
+    name="Julia Nightly Coverage Build",
+    builderNames=[
+        "coverage-linux64",
+    ],
+    hour=[5],
+    change_filter=util.ChangeFilter(
+        project=['JuliaLang/julia'],
+        branch='master',
+    ),
+    onlyIfChanged=True,
+)
+c['schedulers'].append(coverage_nightly_scheduler)
 
 c['schedulers'].append(schedulers.ForceScheduler(
     name="force_coverage",
     label="Force coverage build",
-    builderNames=julia_coverage_builders,
+    builderNames=["coverage-linux64"],
     reason=util.FixedParameter(name="reason", default=""),
     codebases=[
         util.CodebaseParameter(
@@ -197,7 +206,7 @@ c['schedulers'].append(schedulers.ForceScheduler(
 
 # Add coverage builders
 c['builders'].append(util.BuilderConfig(
-    name="coverage_linux64",
+    name="coverage-linux64",
     workernames=["tabularasa_" + x for x in builder_mapping["linux64"]],
     tags=["Coverage"],
     factory=julia_coverage_factory

--- a/master/separated_testing.py
+++ b/master/separated_testing.py
@@ -40,7 +40,7 @@ def render_upload_debugging_files(props_obj):
     """.format(**props)
     return ["bash", "-c", upload_script]
 
-# Steps to download a linux tarball, extract it, run testing on it, and maybe trigger coverage
+# Steps to download a linux tarball, extract it and run tests on it
 julia_testing_factory = util.BuildFactory()
 julia_testing_factory.useProgress = True
 julia_testing_factory.addSteps([
@@ -109,23 +109,6 @@ julia_testing_factory.addSteps([
         doStepIf=should_promote_latest,
     ),
 
-    # Trigger coverage build if everything goes well
-    steps.Trigger(
-        schedulerNames=["Julia Coverage Testing"],
-        set_properties={
-            'download_url': render_download_url,
-            'commitmessage': util.Property('commitmessage'),
-            'commitname': util.Property('commitname'),
-            'commitemail': util.Property('commitemail'),
-            'authorname': util.Property('authorname'),
-            'authoremail': util.Property('authoremail'),
-            'shortcommit': util.Property('shortcommit'),
-            'scheduler': util.Property('scheduler'),
-        },
-        waitForFinish=False,
-        doStepIf=is_assert_nightly,
-    ),
-    
     # Trigger a build of a non-assert version if the assert version finished properly
     steps.Trigger(
         schedulerNames=["Julia CI (non-assert build)"],


### PR DESCRIPTION
When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.
