### PR TITLE
Unconditionally load Pkg and Dates

### DIFF
--- a/commands/rr_capture.jl
+++ b/commands/rr_capture.jl
@@ -8,8 +8,10 @@ const TIMEOUT = 2*60*60 # seconds
 run_id = popfirst!(ARGS)
 shortcommit = popfirst!(ARGS)
 
+using Pkg, Dates
+
 if VERSION >= v"1.6.0-DEV.1087"
-    using Pkg, Dates, Tar
+    using Tar
 end
 
 if VERSION < v"1.6.0-DEV.1087"


### PR DESCRIPTION
This fixes an issue with the `dateformat` string macro, which doesn't expand properly at parse time unless Dates has been loaded.

Should fix the current 64-bit Linux failure on the 1.5.4 backports PR.