### PR TITLE
Organize `make` output better

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -53,8 +53,8 @@ for name in all_names:
     # except for FreeBSD, on which it is `gmake`
     make_cmd = "make"
 
-    # Everything should be VERBOSE and readable afterwards
-    flags = 'VERBOSE=1 --output-sync=target '
+    # Everything should be VERBOSE
+    flags = 'VERBOSE=1 '
 
     # Add on the tagged release banner
     flags += 'TAGGED_RELEASE_BANNER="Official https://julialang.org/ release" '
@@ -99,6 +99,10 @@ for name in all_names:
         os_name = "linux"
         os_pkg_ext = "tar.gz"
 
+    if os_name != "mac"
+        # Organize the output to make it clearer later, when using gmake > v4.0
+        flags += '--output-sync=target '
+        
     # Use ccache everywhere
     flags += 'USECCACHE=1 '
 

--- a/master/inventory.py
+++ b/master/inventory.py
@@ -53,8 +53,8 @@ for name in all_names:
     # except for FreeBSD, on which it is `gmake`
     make_cmd = "make"
 
-    # Everything should be VERBOSE
-    flags = 'VERBOSE=1 '
+    # Everything should be VERBOSE and readable afterwards
+    flags = 'VERBOSE=1 --output-sync=target '
 
     # Add on the tagged release banner
     flags += 'TAGGED_RELEASE_BANNER="Official https://julialang.org/ release" '

--- a/master/nightly_gc_debug.py
+++ b/master/nightly_gc_debug.py
@@ -47,7 +47,7 @@ julia_gc_debug_factory.addSteps([
     # Make!
     steps.ShellCommand(
         name="make",
-        command=["/bin/sh", "-c", util.Interpolate("%(prop:make_cmd)s -j3 %(prop:flags)s")],
+        command=["/bin/sh", "-c", util.Interpolate("%(prop:make_cmd)s -j%(prop:nthreads)s %(prop:flags)s")],
         haltOnFailure = True
     ),
 

--- a/master/nightly_threading.py
+++ b/master/nightly_threading.py
@@ -64,7 +64,7 @@ julia_threading_factory.addSteps([
     # Make!
     steps.ShellCommand(
         name="make binary-dist",
-        command=["/bin/sh", "-c", util.Interpolate("%(prop:make_cmd)s -j3 %(prop:flags)s binary-dist")],
+        command=["/bin/sh", "-c", util.Interpolate("%(prop:make_cmd)s -j%(prop:nthreads)s %(prop:flags)s binary-dist")],
         haltOnFailure = True
     ),
 


### PR DESCRIPTION
Assumes make >= v4.0 from many years ago (n.b. this version is NOT available on macOS, which is v3.81)