### PR TITLE
Only add `--output-sync=target` on Windows/FreeBSD

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -99,7 +99,7 @@ for name in all_names:
         os_name = "linux"
         os_pkg_ext = "tar.gz"
 
-    if os_name != "mac":
+    if os_name in ["win", "freebsd"]:
         # Organize the output to make it clearer later, when using gmake > v4.0
         flags += '--output-sync=target '
         


### PR DESCRIPTION
These are the only buildbot platforms that have `make` >= `v4`, it seems.