### PR TITLE
Add back code signing of the julia executable

### DIFF
--- a/master/package.py
+++ b/master/package.py
@@ -122,6 +122,14 @@ julia_package_factory.addSteps([
         property="dummy",
     ),
 
+    # Sign the julia exectuable julia.exe
+    steps.ShellCommand(
+        name="sign .exe (julia)",
+        command=["sh", "-c", util.Interpolate("~/sign.sh usr/bin/julia.exe")],
+        doStepIf=is_windows,
+        hideStepIf=lambda results, s: results==SKIPPED,
+    ),
+ 
     # Make binary-dist to package it up
     steps.ShellCommand(
         name="make binary-dist",


### PR DESCRIPTION
This propagates to the tarballs that we ship and also the packaged installer

When opening an issue, please ping @staticfloat

close: https://github.com/JuliaCI/julia-buildbot/issues/201