### PR TITLE
disable analyzegc&llvmpasses in favour of buildkite

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -143,9 +143,9 @@ exec(open("builder_utils.py").read())
 # Load in packaging, separated testing and GC analysis (all the stuff we run per-commit)
 exec(open("package.py").read())
 exec(open("separated_testing.py").read())
-exec(open("analyzegc.py").read())
+# exec(open("analyzegc.py").read())
 exec(open("doctest.py").read())
-exec(open("llvmpasses.py").read())
+# exec(open("llvmpasses.py").read())
 exec(open("whitespace.py").read())
 
 # Cleaning


### PR DESCRIPTION
Disable analyzegc and llvmpasses for now.

x-ref: https://buildkite.com/julialang/julia/builds/200

Should wait until we figure out why buildkite didn't trigger on
https://github.com/JuliaLang/julia/pull/40774#issuecomment-844657139

cc: @staticfloat

