### PR TITLE
Code coverage: TEMPORARILY hard-code the list of external stdlibs

### DIFF
--- a/master/coverage.py
+++ b/master/coverage.py
@@ -72,10 +72,22 @@ let
         # "stdlib/Statistics/"
         return prefixes
     end
-    external_stdlib_prefixes = get_external_stdlib_prefixes("stdlib")
+    # external_stdlib_prefixes = get_external_stdlib_prefixes("stdlib")
+    external_stdlib_prefixes = String[
+        "stdlib/ArgTools/",
+        "stdlib/Downloads/",
+        "stdlib/LibCURL/",
+        "stdlib/NetworkOptions/",
+        "stdlib/Pkg/",
+        "stdlib/Statistics/",
+        "stdlib/SuiteSparse/",
+        "stdlib/Tar/",
+    ]
     filter!(results) do c
         all(p -> !startswith(c.filename, p), external_stdlib_prefixes)
     end
+    @info "" pwd() # debugging statement; remove later
+    @info "" readdir(pwd()) # debugging statement; remove later
 end
   # attempt to improve accuracy of the results
 foreach(Coverage.amend_coverage_from_src!, results)


### PR DESCRIPTION
This is only a short-term temporary fix to get coverage submission working again.

Long-term, I do want to get the "automatically generate the list of external stdlibs" feature working. Unfortunately, this feature requires that we have a checkout of the `JuliaLang/julia` source code, because we use the source code to generate the list (we look for files of the form `stdlib/*.version` as a way of identifying external stdlibs).

Right now, IIUC, the coverage buildbot doesn't actually have a checkout of the source code, so we'll need to figure out how to get the source code in order to get the automatic feature working.

Anyway, for now this PR hardcodes the list, and this should fix coverage submission.