### PR TITLE
Code coverage: Only include Julia source files that are either in the top-level `base/` directory or in any subdirectory named `*/src/`

### DIFF
--- a/master/coverage.py
+++ b/master/coverage.py
@@ -16,9 +16,9 @@ Pkg.activate("CoverageBase")
 using Coverage, CoverageBase
 # Process code-coverage files
 results = Coverage.LCOV.readfolder(raw"%(prop:juliadir)s/LCOV")
-  # remove test/ files
+  # remove `test/` files, `benchmark/` files, etc.
 filter!(results) do c
-    !occursin("test/", c.filename)
+    occursin(r"^base/", c.filename) || occursin("/src/", c.filename)
 end
   # turn absolute paths into relative, and add base/ to relative paths
 CoverageBase.fixpath!(results)


### PR DESCRIPTION
The purpose of this PR is to make sure we exclude files such as `stdlib/TOML/benchmark/benchmarks.jl` (https://codecov.io/gh/JuliaLang/julia/src/master/stdlib/TOML/benchmark/benchmarks.jl).