### PR TITLE
Add `freebsd-x86_64-amdci6_4`, `freebsd-x86_64-amdci6_5`, and `freebsd-x86_64-amdci6_6`

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -35,6 +35,7 @@ macos_names     = build_names("macos", ["x86_64"], ["macmini", "macmini2", "macm
 macos_names    += build_names("macos", ["x86_64"], ["macmini-x64-%d"%(idx) for idx in range(1,7)])
 macos_names    += build_names("macos", ["aarch64"], ["macmini-aarch64-%d"%(idx) for idx in range(1,3)])
 freebsd_names   = build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(1,4)])
+freebsd_names  += build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(4,7)])
 all_names       = win_names + linux_names + musl_names + macos_names + freebsd_names
 
 # Define all the attributes we'll use in our buildsteps


### PR DESCRIPTION
For now, I'd like to add three new FreeBSD VMs. I haven't yet deleted the old VMs. So I'd like to add the new ones as 4,5,6.