### PR TITLE
Add some more FreeBSD11 workers, but created fresh

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -35,7 +35,7 @@ macos_names     = build_names("macos", ["x86_64"], ["macmini", "macmini2", "macm
 macos_names    += build_names("macos", ["x86_64"], ["macmini-x64-%d"%(idx) for idx in range(1,7)])
 macos_names    += build_names("macos", ["aarch64"], ["macmini-aarch64-%d"%(idx) for idx in range(1,3)])
 freebsd_names   = build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(1,4)])
-freebsd_names  += build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(4,7)])
+freebsd_names  += build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(4,10)])
 all_names       = win_names + linux_names + musl_names + macos_names + freebsd_names
 
 # Define all the attributes we'll use in our buildsteps


### PR DESCRIPTION
1,2,3: the originals. FreeBSD11. Maybe there is something wrong with the VM disk images now?

4,5,6: FreeBSD12. Created from scratch today from a FreeBSD-12.2 ISO.

7,8,9: FreeBSD11. Created from scratch from a new FreeBSD-11 ISO.