### PR TITLE
Upgrade the FreeBSD buildbots to FreeBSD 12

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -34,8 +34,7 @@ musl_names      = build_names("musl", ["x86_64"], ["nureha_1"])
 macos_names     = build_names("macos", ["x86_64"], ["macmini", "macmini2", "macmini3"])
 macos_names    += build_names("macos", ["x86_64"], ["macmini-x64-%d"%(idx) for idx in range(1,7)])
 macos_names    += build_names("macos", ["aarch64"], ["macmini-aarch64-%d"%(idx) for idx in range(1,3)])
-freebsd_names   = build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(1,4)])
-freebsd_names  += build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(4,10)])
+freebsd_names   = build_names("freebsd", ["x86_64"], ["amdci6_%d"%(idx) for idx in range(4,7)])
 all_names       = win_names + linux_names + musl_names + macos_names + freebsd_names
 
 # Define all the attributes we'll use in our buildsteps
@@ -89,7 +88,7 @@ for name in all_names:
         os_name = "freebsd"
         os_pkg_ext = "tar.gz"
         make_cmd = "gmake"
-        # flags += 'USE_BINARYBUILDER_LIBUV=0 ' # On FreeBSD 12 and later: https://github.com/JuliaLang/julia/issues/34627
+        flags += 'USE_BINARYBUILDER_LIBUV=0 ' # On FreeBSD 12 and later: https://github.com/JuliaLang/julia/issues/34627
 
     elif name[:4] == "musl":
         os_name = "musl"


### PR DESCRIPTION
1. I shutdown the old workers that were running FreeBSD 11. These were the workers with names ending in `amdci6_1`, `amdci6_2`, `amdci6_3`.
2. I have started three new workers that are running FreeBSD 12. These workers have names ending in `amdci6_4`, `amdci6_5`, `amdci6_6`.
3. Since we are now using FreeBSD 12, we need to do `gmake USE_BINARYBUILDER_LIBUV=0`. For details, see:
    - https://github.com/JuliaLang/julia/issues/34627

cc: @staticfloat @ararslan 