### PR TITLE
Remove a redundant flag

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -87,7 +87,6 @@ for name in all_names:
     elif name[:7] == "freebsd":
         os_name = "freebsd"
         os_pkg_ext = "tar.gz"
-        flags += 'USE_BINARYBUILDER_LIBUV=0 ' # On FreeBSD 12 and later: https://github.com/JuliaLang/julia/issues/34627
         make_cmd = "gmake"   
     elif name[:4] == "musl":
         os_name = "musl"


### PR DESCRIPTION
We are now setting this in `package.py`, so we don't also need to set this in `inventory.py`.