### PR TITLE
Slack generator: TEMPORARILY don't post Slack messages for failures of `tester_freebsd64`

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -171,6 +171,7 @@ status_builders = [k for k in builder_mapping.keys()]
 report_builders = [("package_" + k) for k in status_builders if not k in ("linuxarmv7l", "musl64")] + \
                   [("tester_"   + k) for k in status_builders if not k in ("linuxarmv7l", "linuxppc64le", "musl64")] + \
                   ["analyzegc_linux64", "doctest_linux64", "llvmpasses_linux64", "whitespace_linux32"]
+# FIXME: Remove the restriction once FreeBSD CI works again
 slack_builders = [k for k in report_builders if not k in ("tester_freebsd64")]
 status_generator = BuildStartEndStatusGenerator(
     builders=report_builders,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -171,6 +171,7 @@ status_builders = [k for k in builder_mapping.keys()]
 report_builders = [("package_" + k) for k in status_builders if not k in ("linuxarmv7l", "musl64")] + \
                   [("tester_"   + k) for k in status_builders if not k in ("linuxarmv7l", "linuxppc64le", "musl64")] + \
                   ["analyzegc_linux64", "doctest_linux64", "llvmpasses_linux64", "whitespace_linux32"]
+slack_builders = [k for k in report_builders if not k in ("tester_freebsd64")]
 status_generator = BuildStartEndStatusGenerator(
     builders=report_builders,
     start_formatter=reporters.MessageFormatterRenderable('Build started.'),
@@ -186,7 +187,7 @@ c['services'].append(package_report)
 # Add failed build reporting
 exec(open("slack_failure.py").read())
 slack_generator = BuildStatusGenerator(
-    builders=report_builders,
+    builders=slack_builders,
     message_formatter=reporters.MessageFormatterFunction(slack_failed_build, 'json'),
 )
 failed_report = reporters.HttpStatusPush(


### PR DESCRIPTION
Just for now. We'll revert this once `tester_freebsd64` is passing against on `master`.