### PR TITLE
Do not rerun all Buildbot jobs when someone closes and reopens a pull request

### DIFF
--- a/master/github_listener.py
+++ b/master/github_listener.py
@@ -67,7 +67,7 @@ class JuliaGithubListener(GitHubEventHandler):
         head_msg = yield self._get_commit_msg(repo_full_name, head_sha)
 
         action = payload.get('action')
-        if action not in ('opened', 'reopened', 'synchronize'):
+        if action not in ('opened', 'synchronize'):
             log.msg("GitHub PR #{} {}, ignoring".format(number, action))
             return (changes, 'git')
 


### PR DESCRIPTION
Before this PR, when someone closes and reopens a pull request:
1. Buildkite reruns only the failed Buildkite jobs. If there are no failed Buildkite jobs, Buildkite does nothing.
2. Buildbot reruns all Buildbot jobs, whether they passed or failed.

After this PR, when someone closes and reopens a pull request:
1. Buildkite reruns only the failed Buildkite jobs. If there are no failed Buildkite jobs, Buildkite does nothing.
2. Buildbot does nothing.

After this PR is merged, if someone wants to retry a failed Buildbot job, they can ask a committer to log in to build.julialang.org and retry the job.

---

In the event that someone really does need to rerun all CI jobs, they can do either of the following:
1. Push a new commit.
2. Amend their last commit, and then force-push the amended commit.

Doing either of the above will rerun all CI jobs (both Buildbot and Buildkite).

So if someone really does need to rerun all CI jobs, there are still ways for them to accomplish this.