### PR TITLE
Make it explicitly clear that we are skipping the `Pkg` and `Pkg/pkg` test sets

### DIFF
--- a/master/separated_testing.py
+++ b/master/separated_testing.py
@@ -13,7 +13,7 @@ def run_julia_tests(props_obj):
     props = props_obj_to_dict(props_obj)
     # We run all tests, even the ones that require internet connectivity.  Note that
     # it appears the windows shell can't deal with newlines.  :/
-    test_cmd = """include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test", "choosetests.jl")); Base.runtests(append!(choosetests()[1], ["LibGit2/online", "download"]); ncores=min(Sys.CPU_THREADS, 8, {nthreads}))""".format(**props)
+    test_cmd = """include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test", "choosetests.jl")); Base.runtests(append!(choosetests()[1], ["LibGit2/online", "download", "--skip", "Pkg", "Pkg/pkg"]); ncores=min(Sys.CPU_THREADS, 8, {nthreads}))""".format(**props)
 
     cmd = ["bin/julia", "-e", test_cmd]
     if is_windows(props_obj):


### PR DESCRIPTION
Buildbot is actually already skipping these test sets. But that is not immediately obvious when you are reading this code. So let's make it explicit.