### PR TITLE
Try adding an old branch canceller plugin

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -225,6 +225,15 @@ for name in all_names:
 # the auto_reload builders and whatnot.
 all_names += ["tabularasa_" + x for x in all_names]
 
+# Add `all_names` as things that should have old builds cancelled for pushes
+# to branches, except for `master` and `release-*` branches
+c['services'] += [
+    OldBuildCanceller(
+        "build_canceller",
+        [(all_names, SourceStampFilter(branch_not_re=r"^(master|release-\d+\.\d+)$"))],
+    )
+]
+
 # Build a nicer mapping for us.  This is how we know things like "package_linux64"
 # runs on "linux-x86_64-nanosoldier2_1", for instance.
 namefilt = lambda arch, names: [n for n in names if arch in n]

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1,6 +1,8 @@
 from buildbot.plugins import *
+from buildbot.plugins.util import OldBuildCanceller
 from buildbot.plugins import worker as bworker
 from buildbot.process.results import SKIPPED
+from buildbot.util.ssfilter import SourceStampFilter
 from datetime import timedelta
 from github_listener import JuliaGithubListener
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator, BuildStatusGenerator

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1,5 +1,5 @@
 from buildbot.plugins import *
-from buildbot.plugins.util import OldBuildCanceller
+from buildbot.schedulers.canceller import OldBuildCanceller
 from buildbot.plugins import worker as bworker
 from buildbot.process.results import SKIPPED
 from buildbot.util.ssfilter import SourceStampFilter


### PR DESCRIPTION
We want to cancel old builds on PRs but not on `master`, since we'd like to have a list of green checkmarks
