### PR TITLE
Increase the tester timeout from 4 hours to 5 hours

### DIFF
--- a/master/separated_testing.py
+++ b/master/separated_testing.py
@@ -84,8 +84,8 @@ julia_testing_factory.addSteps([
         # NOTE: Windows buildbots have a separate timeout of 2 hours total (regardless of stdout activity)
         # enforced by the autodump script.  We should eventually move everything over to that.
         timeout=122*60,
-        # Kill everything if the overall job has taken more than 4 hours
-        maxTime=60*60*4,
+        # Kill everything if the overall job has taken more than 5 hours
+        maxTime=60*60*5,
         # Give the process 10 seconds to print out the current backtraces when being killed
         sigtermTime=10,
         env=julia_testing_env,


### PR DESCRIPTION
I keep seeing jobs that timeout at 4 hours, but they are nearly finished, e.g. they are running the "node 1 only" tests.

Here's an example: https://build.julialang.org/#/builders/17/builds/1484