### PR TITLE
Try unlocking keychain before `make binary-dist`

### DIFF
--- a/master/package.py
+++ b/master/package.py
@@ -140,7 +140,7 @@ julia_package_factory.addSteps([
     
     # Unlock keychain before binary-dist, which uses keychain items now
     steps.ShellCommand(
-        name="make .app",
+        name="unlock keychain",
         command=["sh", "-c", util.Interpolate("~/unlock_keychain.sh")],
         haltOnFailure=True,
         doStepIf=is_mac,

--- a/master/package.py
+++ b/master/package.py
@@ -137,6 +137,17 @@ julia_package_factory.addSteps([
         doStepIf=is_windows,
         hideStepIf=lambda results, s: results==SKIPPED,
     ),
+    
+    # Unlock keychain before binary-dist, which uses keychain items now
+    steps.ShellCommand(
+        name="make .app",
+        command=["sh", "-c", util.Interpolate("~/unlock_keychain.sh")],
+        haltOnFailure=True,
+        doStepIf=is_mac,
+        hideStepIf=lambda results, s: results==SKIPPED,
+        env=julia_package_env,
+    ),
+
 
     # Make binary-dist to package it up
     steps.ShellCommand(
@@ -155,7 +166,7 @@ julia_package_factory.addSteps([
     # Build .app on macOS
     steps.ShellCommand(
         name="make .app",
-        command=["sh", "-c", util.Interpolate("~/unlock_keychain.sh && make %(prop:flags)s %(prop:extra_make_flags)s app")],
+        command=["sh", "-c", util.Interpolate("make %(prop:flags)s %(prop:extra_make_flags)s app")],
         haltOnFailure=True,
         doStepIf=is_mac,
         hideStepIf=lambda results, s: results==SKIPPED,


### PR DESCRIPTION
I believe the keychain problems we're having now is due to us trying to use keychain objects in `make binary-dist`, and it worked so far because the keychains were remaining unlocked from previous CI runs.  😳  After the buildbots were restarted, everything stonewalled on the `make binary-dist` step, and the keychains were never unlocked.
