### PR TITLE
Un-hook `linux64` from the CI build scheduler

### DIFF
--- a/master/package.py
+++ b/master/package.py
@@ -290,7 +290,7 @@ def julia_branch_nonskip_filter(c):
 c['schedulers'].append(schedulers.AnyBranchScheduler(
     name="Julia CI (assert build)",
     change_filter=util.ChangeFilter(filter_fn=julia_branch_nonskip_filter),
-    builderNames=[k for k in packager_mapping.keys()],
+    builderNames=[k for k in packager_mapping.keys() if k not in ["linux64"]],
     treeStableTimer=1,
     properties={
         "assert_build": True,


### PR DESCRIPTION
This should prevent us from doing linux64 builds on buildbot
