### PR TITLE
Revert "Un-hook `linux64` from the CI build scheduler (#266)"

### DIFF
--- a/master/package.py
+++ b/master/package.py
@@ -290,7 +290,7 @@ def julia_branch_nonskip_filter(c):
 c['schedulers'].append(schedulers.AnyBranchScheduler(
     name="Julia CI (assert build)",
     change_filter=util.ChangeFilter(filter_fn=julia_branch_nonskip_filter),
-    builderNames=[k for k in packager_mapping.keys() if k not in ["package_linux64"]],
+    builderNames=[k for k in packager_mapping.keys()],
     treeStableTimer=1,
     properties={
         "assert_build": True,


### PR DESCRIPTION
This reverts commit 601d707e84ef399c583f404c1a38ad92f605f3fb.

When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.
