### PR TITLE
Fix missing windows builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -110,7 +110,7 @@ def should_promote_latest(props):
 # We use this condition to do things like trigger coverage builds and
 # trigger deployment from a successful test build.
 def is_assert_nightly(props):
-    return should_promote(props) and "linux64" in props.getProperty('buildername') and props.getProperty('assert_build')
+    return should_promote(props) and "win64" in props.getProperty('buildername') and props.getProperty('assert_build')
 
 # Certain buildsteps we only run if the unwashed masses can't submit arbitrary code
 def is_protected_non_pr(props):


### PR DESCRIPTION
We've been lacking nightlies ever since turning off the linux64
builders; this is because we used to us the linux64 builders as the
trigger to start all of our non-assert builds.  Let's switch it over to
win64 for now.