### PR TITLE
Disable _all_ testing on buildbot

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -144,7 +144,7 @@ exec(open("builder_utils.py").read())
 
 # Load in packaging, separated testing and GC analysis (all the stuff we run per-commit)
 exec(open("package.py").read())
-exec(open("separated_testing.py").read())
+#exec(open("separated_testing.py").read())
 # exec(open("analyzegc.py").read())
 exec(open("doctest.py").read())
 # exec(open("llvmpasses.py").read())
@@ -171,8 +171,8 @@ exec(open("auto_reload.py").read())
 # and we don't have the bandwidth or cycles to fix right now
 status_builders = [k for k in builder_mapping.keys()]
 report_builders = [("package_" + k) for k in status_builders if not k in ("linuxarmv7l", "musl64")] + \
-                  [("tester_"   + k) for k in status_builders if not k in ("linuxarmv7l", "linuxppc64le", "musl64")] + \
                   ["analyzegc_linux64", "doctest_linux64", "llvmpasses_linux64", "whitespace_linux32"]
+                  #[("tester_"   + k) for k in status_builders if not k in ("linuxarmv7l", "linuxppc64le", "musl64")] + \
 slack_builders = [k for k in report_builders]
 status_generator = BuildStartEndStatusGenerator(
     builders=report_builders,


### PR DESCRIPTION
Now that we have decided to disable FreeBSD testing, that eliminates the final tester we've been using on buildbot, so let's just disable them all.
